### PR TITLE
Cache events

### DIFF
--- a/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
@@ -313,7 +313,17 @@ namespace Plugin.FirebasePushNotification
         {
             add
             {
+                var previous = _onTokenRefresh;
                 _onTokenRefresh += value;
+
+                if (previous == null)
+                {
+                    var token = Token;
+                    if (!string.IsNullOrEmpty(token))
+                    {
+                        _onTokenRefresh?.Invoke(this, new FirebasePushNotificationTokenEventArgs(Token));
+                    }
+                }
             }
             remove
             {

--- a/src/Plugin.FirebasePushNotification.iOS/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.iOS/FirebasePushNotificationManager.cs
@@ -142,7 +142,7 @@ namespace Plugin.FirebasePushNotification
         
         public static async Task Initialize(NSDictionary options, bool autoRegistration = true, bool enableDelayedResponse = true)
         {
-            enableDelayedResponse = enableDelayedResponse;
+            EnableDelayedResponse = enableDelayedResponse;
             App.Configure();
 
             CrossFirebasePushNotification.Current.NotificationHandler = CrossFirebasePushNotification.Current.NotificationHandler ?? new DefaultPushNotificationHandler();
@@ -150,20 +150,6 @@ namespace Plugin.FirebasePushNotification
             if (autoRegistration)
             {
                 await CrossFirebasePushNotification.Current.RegisterForPushNotifications();
-            }
-
-
-            if (options?.Keys != null && options.Keys.Count() != 0 && options.ContainsKey(new NSString("UIApplicationLaunchOptionsRemoteNotificationKey")))
-            {
-                NSDictionary data = options.ObjectForKey(new NSString("UIApplicationLaunchOptionsRemoteNotificationKey")) as NSDictionary;
-                var response = new NotificationResponse(GetParameters(data));
-
-                if (enableDelayedResponse && _onNotificationOpened == null)
-                {
-                    delayedNotificationResponse = response;
-                }
-
-                _onNotificationOpened?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationResponseEventArgs(response.Data, response.Identifier, response.Type));
             }
 
         }

--- a/src/Plugin.FirebasePushNotification.iOS/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.iOS/FirebasePushNotificationManager.cs
@@ -38,7 +38,17 @@ namespace Plugin.FirebasePushNotification
         {
             add
             {
+                var previous = _onTokenRefresh;
                 _onTokenRefresh += value;
+
+                if (EnableDelayedResponse && previous == null)
+                {
+                    var token = Token;
+                    if (!string.IsNullOrEmpty(token))
+                    {
+                        _onTokenRefresh?.Invoke(this, new FirebasePushNotificationTokenEventArgs(Token));
+                    }
+                }
             }
             remove
             {


### PR DESCRIPTION
Please take a moment to fill out the following:

Makes notification action consistent between platforms.

Changes Proposed in this pull request:
- Allow delayed subscription for the opened event for iOS to follow how Android does it.
- Follows a similar pattern for the OnTokenRefresh. This can be removed if you see a problem with it that I do not, but it allows for auto registering at the beginning and only using it after a sign in or similar approaches.
