### PR TITLE
Updated GettingStarted Document to reflect the same DefaultNotificati…

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -82,7 +82,7 @@ Example of initialization:
 	    if (Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
 	    {
 		 //Change for your default notification channel id here
-	         FirebasePushNotificationManager.DefaultNotificationChannelId = "DefaultChannel";
+	         FirebasePushNotificationManager.DefaultNotificationChannelId = "FirebasePushNotificationChannel";
 
 		 //Change for your default notification channel name here
 		 FirebasePushNotificationManager.DefaultNotificationChannelName = "General";


### PR DESCRIPTION
Updated GettingStarted Document to reflect the same DefaultNotificationChannelId (FirebasePushNotificationChannel) in android project. This helps new people (wish I would have known this) with getting Android Notifications on Oreo to show up with the app in the foreground.

Please take a moment to fill out the following:

Fixes # #166

Changes Proposed in this pull request:
- Changed the GettingStarted Document to reflect the DefaultNotificationChannelId default parameter in the FirebasePushNotificationManager.cs
-
- 
