### PR TITLE
Fix bug when using topic names that are substrings of other topic names.

### DIFF
--- a/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
@@ -450,7 +450,7 @@ namespace Plugin.FirebasePushNotification
         public void Subscribe(string topic)
         {
 
-            if (!currentTopics.Contains((topic)))
+            if (!currentTopics.Equals((topic)))
             {
                 FirebaseMessaging.Instance.SubscribeToTopic(topic);
                 currentTopics.Add(topic);
@@ -472,7 +472,7 @@ namespace Plugin.FirebasePushNotification
         {
             foreach (var t in currentTopics)
             {
-                if (currentTopics.Contains(t))
+                if (currentTopics.Equals(t))
                 {
                     FirebaseMessaging.Instance.UnsubscribeFromTopic(t);
                 }
@@ -487,7 +487,7 @@ namespace Plugin.FirebasePushNotification
 
         public void Unsubscribe(string topic)
         {
-            if (currentTopics.Contains(topic))
+            if (currentTopics.Equals(topic))
             {
                 FirebaseMessaging.Instance.UnsubscribeFromTopic(topic);
                 currentTopics.Remove(topic);

--- a/src/Plugin.FirebasePushNotification.iOS/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.iOS/FirebasePushNotificationManager.cs
@@ -421,7 +421,7 @@ namespace Plugin.FirebasePushNotification
                 return;
             }
             
-            if (!currentTopics.Contains(new NSString(topic)))
+            if (!currentTopics.Equals(new NSString(topic)))
             {
                 Messaging.SharedInstance.Subscribe($"{topic}");
                 currentTopics.Add(new NSString(topic));
@@ -456,7 +456,7 @@ namespace Plugin.FirebasePushNotification
                 return;
             }
             var deletedKey = new NSString($"{topic}");
-            if (currentTopics.Contains(deletedKey))
+            if (currentTopics.Equals(deletedKey))
             {
                 Messaging.SharedInstance.Unsubscribe($"{topic}");
                 nint idx = (nint)currentTopics.IndexOf(deletedKey);


### PR DESCRIPTION
Changes Proposed in this pull request:
- Changed Contains to Equals in Subscribe/Unsubscribe functions to allow for topic names that could be substrings of other topic names. Example: "general" and "debug_general" or "legal" and "illegal"
