### PR TITLE
Fix for issues with persisting topics. GetStringSet seems to return a…

### DIFF
--- a/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
@@ -29,7 +29,7 @@ namespace Plugin.FirebasePushNotification
         internal const string AppVersionNameKey = "AppVersionNameKey";
         internal const string AppVersionPackageNameKey = "AppVersionPackageNameKey";
        // internal const string NotificationDeletedActionId = "Plugin.PushNotification.NotificationDeletedActionId";
-        static ICollection<string> currentTopics = Android.App.Application.Context.GetSharedPreferences(KeyGroupName, FileCreationMode.Private).GetStringSet(FirebaseTopicsKey, new Collection<string>());
+        static ICollection<string> currentTopics = new HashSet<string>(Android.App.Application.Context.GetSharedPreferences(KeyGroupName, FileCreationMode.Private).GetStringSet(FirebaseTopicsKey, new Collection<string>()));
         static IList<NotificationUserCategory> userNotificationCategories = new List<NotificationUserCategory>();
         public static string NotificationContentTitleKey { get; set; }
         public static string NotificationContentTextKey { get; set; }


### PR DESCRIPTION
I was seeing an issue where I would subscribe 3 of my topics, but upon restarting the app, only 1 topic was retrieved. It looked like the subscribe methods were working as expected with currentTopics updated correctly, but after restart, only 1 topic was retrieved.

Changes Proposed in this pull request:
- Makes a copy of the collection set retrieved via the GetStringSet method.
- Use copy of set instead of reference to instance to get/retrieve topics.
