### PR TITLE
Channel importance to High

### DIFF
--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.8.1">
     <id>Plugin.FirebasePushNotification</id>
-    <version>2.3.6</version>
+    <version>2.3.7</version>
     <title>Firebase Push Notification Plugin for Xamarin</title>
     <authors>Rendy Del Rosario</authors>
     <owners>crossgeeks rdelrosario</owners>

--- a/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
+++ b/src/Plugin.FirebasePushNotification.Android/FirebasePushNotificationManager.cs
@@ -221,7 +221,7 @@ namespace Plugin.FirebasePushNotification
                 NotificationManager notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService);
                 
                 notificationManager.CreateNotificationChannel(new NotificationChannel(channelId,
-                    channelName,NotificationImportance.Default));
+                    channelName,NotificationImportance.High));
              }
 
              System.Diagnostics.Debug.WriteLine(CrossFirebasePushNotification.Current.Token);


### PR DESCRIPTION
Hi! I'm been using this plugin from 2017 and think this is amazing. But I have some troubles with heads-up in Android >= O. After reading official documentation, channels needs importante high(urgent) to show heads-up in comparison with "priority = high" to Android < O. I tested in local this change and heads-up is showing as expected :).

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
- Change channel importance to High.
- Update version (to avoid conflict)
- 
