### PR TITLE
iOS. There is a crash when a device is registered in FCM.

### DIFF
--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
@@ -551,16 +551,17 @@ namespace Plugin.FirebasePushNotification
                 while (pendingTopics.Count > 0)
                 {
                     var pTopic = pendingTopics.Dequeue();
-
-                    if (pTopic.Item2)
+                    if (pTopic != null)
                     {
-                        CrossFirebasePushNotification.Current.Subscribe(pTopic.Item1);
+                        if (pTopic.Item2)
+                        {
+                            CrossFirebasePushNotification.Current.Subscribe(pTopic.Item1);
+                        }
+                        else
+                        {
+                            CrossFirebasePushNotification.Current.Unsubscribe(pTopic.Item1);
+                        }
                     }
-                    else
-                    {
-                        CrossFirebasePushNotification.Current.Unsubscribe(pTopic.Item1);
-                    }
-
                 }
             }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce?
bugfix

### :arrow_heading_down: What is the current behavior?
There is a crash when a device is registered in FCM

### :new: What is the new behavior (if this is a feature change)?
Avoid the crash by adding a validation

### :bug: Recommendations for testing
1. The user setup to receive push notifications.
2. The user doesn't want to receive push notifications (unregister him device from FCM)
3. And then the user tries to register again him device in FCM

The pendingTopics stack has some values in null.

### :thinking: Checklist before submitting

- [ X] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
