### PR TITLE
Fix for crash with UnregisterForPushNotifications

### DIFF
--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
@@ -565,7 +565,7 @@ namespace Plugin.FirebasePushNotification
                 }
             }
 
-            NSUserDefaults.StandardUserDefaults.SetString(fcmToken, FirebaseTokenKey);
+            NSUserDefaults.StandardUserDefaults.SetString(fcmToken ?? string.Empty, FirebaseTokenKey);
         }
 
         public void ClearAllNotifications()


### PR DESCRIPTION
https://github.com/CrossGeeks/FirebasePushNotificationPlugin/issues/367

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
