### PR TITLE
FirebasePushNotificationManager.android.cs#Reset will not terminate app on error anymore

### DIFF
--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.android.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.android.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Firebase.Iid;
 using Firebase.Messaging;
 using System.Collections.Generic;
@@ -198,22 +198,22 @@ namespace Plugin.FirebasePushNotification
             RegisterUserNotificationCategories(notificationCategories);
 
         }
+    
         public static void Reset()
         {
-            try
+            ThreadPool.QueueUserWorkItem(state =>
             {
-                ThreadPool.QueueUserWorkItem(state =>
+                try
                 {
                     CleanUp();
-                });
-            }
-            catch (Exception ex)
-            {
-                _onNotificationError?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationErrorEventArgs(FirebasePushNotificationErrorType.UnregistrationFailed, ex.ToString()));
-            }
-
-
+                }
+                catch (Exception ex)
+                {
+                    _onNotificationError?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationErrorEventArgs(FirebasePushNotificationErrorType.UnregistrationFailed, ex.ToString()));
+                }
+            });
         }
+
         public void RegisterForPushNotifications()
         {
             FirebaseMessaging.Instance.AutoInitEnabled = true;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
`Reset` calls `CleanUp` which is queued to a threadpool thread. This means `CleanUp` is not immediately executed, but later when a thread is available. Therefore if an exception occurs in `CleanUp` it will not be caught by the try-catch surrounding `QueueUserWorkItem`. Instead the execution will be thrown on the threadpool thread, not be observed (i.e. caught) and the application will be terminated.

### :new: What is the new behavior (if this is a feature change)?
Any exception of `CleanUp` is caught and thus will no longer terminate the application.
I believe it was the original intention that the application does not terminate on an exception, but instead that the `NotificationError` event handler would be called.

### :boom: Does this PR introduce a breaking change?
This is not a breaking change, in the sense that before the application would just terminate, but now doesn't. Therefore, it is unlikely that a user has used `Reset` or `UnregisterForPushNotifications` (which calls `Reset`) with the expectation that his app will be terminated if the action fails.
Rather it was documented behaviour that the `NotificationError` event handler would be called, which is now the case.

### :bug: Recommendations for testing
None.

### :memo: Links to relevant issues/docs
None.

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
