### PR TITLE
Add PendingIntentFlags.Immutable to DefaultPushNotificationHandler.android 

### DIFF
--- a/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
+++ b/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
@@ -358,7 +358,7 @@ namespace Plugin.FirebasePushNotification
             }
             var requestCode = new Java.Util.Random().NextInt();
 
-            var pendingIntent = PendingIntent.GetActivity(context, requestCode, resultIntent, PendingIntentFlags.UpdateCurrent);
+            var pendingIntent = PendingIntent.GetActivity(context, requestCode, resultIntent, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
             if (parameters.TryGetValue(ChannelIdKey, out var channelId) && channelId != null)
             {
@@ -387,7 +387,7 @@ namespace Plugin.FirebasePushNotification
 
             var deleteIntent = new Intent(context, typeof(PushNotificationDeletedReceiver));
             deleteIntent.PutExtras(extras);
-            var pendingDeleteIntent = PendingIntent.GetBroadcast(context, requestCode, deleteIntent, PendingIntentFlags.CancelCurrent);
+            var pendingDeleteIntent = PendingIntent.GetBroadcast(context, requestCode, deleteIntent, PendingIntentFlags.CancelCurrent | PendingIntentFlags.Immutable);
             notificationBuilder.SetDeleteIntent(pendingDeleteIntent);
 
             if (Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.O)
@@ -503,7 +503,7 @@ namespace Plugin.FirebasePushNotification
 
                                     extras.PutString(ActionIdentifierKey, action.Id);
                                     actionIntent.PutExtras(extras);
-                                    pendingActionIntent = PendingIntent.GetActivity(context, aRequestCode, actionIntent, PendingIntentFlags.UpdateCurrent);
+                                    pendingActionIntent = PendingIntent.GetActivity(context, aRequestCode, actionIntent, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
                                 }
                                 else
@@ -511,7 +511,7 @@ namespace Plugin.FirebasePushNotification
                                     actionIntent = new Intent(context, typeof(PushNotificationActionReceiver));
                                     extras.PutString(ActionIdentifierKey, action.Id);
                                     actionIntent.PutExtras(extras);
-                                    pendingActionIntent = PendingIntent.GetBroadcast(context, aRequestCode, actionIntent, PendingIntentFlags.UpdateCurrent);
+                                    pendingActionIntent = PendingIntent.GetBroadcast(context, aRequestCode, actionIntent, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
                                 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? 

Bug fix


### :arrow_heading_down: What is the current behavior? 

Currently NO PendingIntentFlags.Immutable is applied when building a notification. After Android 12 this causes the application the crash upon receiving a push notification with following error: 

Java.Lang.IllegalArgumentException
Message=bg.acc.smartpark: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.

### :new: What is the new behavior (if this is a feature change)? 

App does not crash upon receiving a Push Notification from FCM


### :boom: Does this PR introduce a breaking change? 

No


### :bug: Recommendations for testing 

None


### :memo: Links to relevant issues/docs

https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability 

### :thinking: Checklist before submitting

- [ ✓] All projects build
- [ ✓] Follows style guide lines 
- [ ✓] Relevant documentation was updated
- [ ✓] Rebased onto current develop
