### PR TITLE
Make NotificationCompat.BigTextStyle optional [Android]

### DIFF
--- a/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
+++ b/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -139,6 +139,11 @@ namespace Plugin.FirebasePushNotification
         /// </summary>
         public const string ShowWhenKey = "show_when";
 
+        /// <summary>
+        /// Use BigText notification style to support long message
+        /// </summary>
+        public const string BigTextStyleKey = "bigtextstyle";
+
         public virtual void OnOpened(NotificationResponse response)
         {
             System.Diagnostics.Debug.WriteLine($"{DomainTag} - OnOpened");
@@ -160,6 +165,7 @@ namespace Plugin.FirebasePushNotification
             var message = string.Empty;
             var tag = string.Empty;
             var showWhenVisible = FirebasePushNotificationManager.ShouldShowWhen;
+            var useBigTextStyle = FirebasePushNotificationManager.UseBigTextStyle;
             var soundUri = FirebasePushNotificationManager.SoundUri;
             var largeIconResource = FirebasePushNotificationManager.LargeIconResource;
             var smallIconResource = FirebasePushNotificationManager.IconResource;
@@ -223,6 +229,11 @@ namespace Plugin.FirebasePushNotification
             if (parameters.TryGetValue(ShowWhenKey, out var shouldShowWhen))
             {
                 showWhenVisible = $"{shouldShowWhen}".ToLower() == "true";
+            }
+
+            if (parameters.TryGetValue(BigTextStyleKey, out var shouldUseBigTextStyle))
+            {
+                useBigTextStyle = $"{shouldUseBigTextStyle}".ToLower() == "true";
             }
 
             if (parameters.TryGetValue(TagKey, out var tagContent))
@@ -457,7 +468,7 @@ namespace Plugin.FirebasePushNotification
                 notificationBuilder.SetColor(notificationColor.Value);
             }
 
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
+            if (useBigTextStyle && Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
             {
                 // Using BigText notification style to support long message
                 var style = new NotificationCompat.BigTextStyle();

--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.android.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.android.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Firebase.Messaging;
 using System.Collections.Generic;
 using Android.Content;
@@ -38,6 +38,7 @@ namespace Plugin.FirebasePushNotification
         public static int IconResource { get; set; }
         public static int LargeIconResource { get; set; }
         public static bool ShouldShowWhen { get; set; } = true;
+        public static bool UseBigTextStyle { get; set; } = true;
         public static Android.Net.Uri SoundUri { get; set; }
         public static Color? Color { get; set; }
         public static Type NotificationActivityType { get; set; }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature
### :arrow_heading_down: What is the current behavior?
 Because BigTextStyle is always set it is impossible to use BigPictureStyle. If BigTextStyle is set, then adding BigPictureStyle in OnBuildNotification is impossible.

### :new: What is the new behavior (if this is a feature change)?
Changing the setting UseBigTextStyle to false via code or data parameters will skip the NotificationCompat.BigTextStyle style.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
