### PR TITLE
Make Android OnReceived condition virtual, fix UnsubscribeAll ios Bug and Update to new firebase sdk

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -60,7 +60,7 @@
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(IsLibraryProject)' == 'true'">
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -71,15 +71,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="2.3.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AsyncFixer" Version="1.1.6">
+    <PackageReference Include="AsyncFixer" Version="1.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
+++ b/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -228,12 +228,12 @@ namespace Plugin.FirebasePushNotification
 
             if (parameters.TryGetValue(ShowWhenKey, out var shouldShowWhen))
             {
-                showWhenVisible = $"{shouldShowWhen}".ToLower() == "true";
+                showWhenVisible = $"{shouldShowWhen}".Equals("true", StringComparison.CurrentCultureIgnoreCase);
             }
 
             if (parameters.TryGetValue(BigTextStyleKey, out var shouldUseBigTextStyle) && shouldUseBigTextStyle != null)
             {
-                useBigTextStyle = $"{shouldUseBigTextStyle}".ToLower() == "true";
+                useBigTextStyle = $"{shouldUseBigTextStyle}".Equals("true", StringComparison.CurrentCultureIgnoreCase);
             }
 
             if (parameters.TryGetValue(TagKey, out var tagContent))

--- a/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
+++ b/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs
@@ -153,7 +153,7 @@ namespace Plugin.FirebasePushNotification
         {
             System.Diagnostics.Debug.WriteLine($"{DomainTag} - OnReceived");
 
-            if ((parameters.TryGetValue(SilentKey, out var silent) && (silent.ToString() == "true" || silent.ToString() == "1")) || (IsInForeground() && (!(!parameters.ContainsKey(ChannelIdKey) && parameters.TryGetValue(PriorityKey, out var imp) && ($"{imp}" == "high" || $"{imp}" == "max")) || (!parameters.ContainsKey(PriorityKey) && !parameters.ContainsKey(ChannelIdKey) && FirebasePushNotificationManager.DefaultNotificationChannelImportance != NotificationImportance.High && FirebasePushNotificationManager.DefaultNotificationChannelImportance != NotificationImportance.Max))))
+            if (SkipNotificationProcessing(parameters))
             {
                 return;
             }
@@ -605,6 +605,18 @@ namespace Plugin.FirebasePushNotification
         /// <param name="notificationBuilder">Notification builder.</param>
         /// <param name="parameters">Notification parameters.</param>
         public virtual void OnBuildNotification(NotificationCompat.Builder notificationBuilder, IDictionary<string, object> parameters) { }
+
+        /// <summary>
+        /// Override to implement own condition to skip notification processing or not.
+        /// </summary>
+        /// <param name="parameters">Notification parameters.</param>
+        /// <returns>true to skip processing or false to continue</returns>
+        public virtual bool SkipNotificationProcessing(IDictionary<string, object> parameters)
+        {
+            var result = (parameters.TryGetValue(SilentKey, out var silent) && (silent.ToString() == "true" || silent.ToString() == "1")) || (IsInForeground() && (!(!parameters.ContainsKey(ChannelIdKey) && parameters.TryGetValue(PriorityKey, out var imp) && ($"{imp}" == "high" || $"{imp}" == "max")) || (!parameters.ContainsKey(PriorityKey) && !parameters.ContainsKey(ChannelIdKey) && FirebasePushNotificationManager.DefaultNotificationChannelImportance != NotificationImportance.High && FirebasePushNotificationManager.DefaultNotificationChannelImportance != NotificationImportance.Max)));
+            System.Diagnostics.Debug.WriteLine($"{DomainTag} - {nameof(SkipNotificationProcessing)}: {result}");
+            return result;
+        }
 
         private bool IsInForeground()
         {

--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.android.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.android.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Firebase.Messaging;
 using System.Collections.Generic;
 using Android.Content;
@@ -61,9 +61,9 @@ namespace Plugin.FirebasePushNotification
                 var parameters = new Dictionary<string, object>();
                 foreach (var key in extras.KeySet())
                 {
-                    if (!parameters.ContainsKey(key) && extras.Get(key) != null)
+                    if (!parameters.ContainsKey(key) && !string.IsNullOrWhiteSpace(extras.GetString(key)))
                     {
-                        parameters.Add(key, $"{extras.Get(key)}");
+                        parameters.Add(key, extras.GetString(key));
                     }
                 }
 
@@ -197,7 +197,7 @@ namespace Plugin.FirebasePushNotification
             RegisterUserNotificationCategories(notificationCategories);
 
         }
-    
+
         public static void Reset()
         {
             ThreadPool.QueueUserWorkItem(state =>

--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Firebase.CloudMessaging;
 using Firebase.Core;
-using Firebase.InstanceID;
+//using Firebase.InstanceID; //Old
 using Foundation;
 using UIKit;
 using UserNotifications;
@@ -302,7 +302,8 @@ namespace Plugin.FirebasePushNotification
             Messaging.SharedInstance.AutoInitEnabled = false;
             UIApplication.SharedApplication.UnregisterForRemoteNotifications();
             NSUserDefaults.StandardUserDefaults.SetString(string.Empty, FirebaseTokenKey);
-            InstanceId.SharedInstance.DeleteId((h) => { });
+            Messaging.SharedInstance.DeleteToken((h) => { });
+            //InstanceId.SharedInstance.DeleteId((h) => { }); Old
         }
         // To receive notifications in foreground on iOS 10 devices.
         [Export("userNotificationCenter:willPresentNotification:withCompletionHandler:")]
@@ -315,7 +316,7 @@ namespace Plugin.FirebasePushNotification
             _onNotificationReceived?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationDataEventArgs(parameters));
             CrossFirebasePushNotification.Current.NotificationHandler?.OnReceived(parameters);
 
-            if ((parameters.TryGetValue("priority", out var priority) && ($"{priority}".ToLower() == "high" || $"{priority}".ToLower() == "max")))
+            if ((parameters.TryGetValue("priority", out var priority) && ($"{priority}".Equals("high", StringComparison.CurrentCultureIgnoreCase) || $"{priority}".Equals("max", StringComparison.CurrentCultureIgnoreCase))))
             {
                 if (!CurrentNotificationPresentationOption.HasFlag(UNNotificationPresentationOptions.Alert))
                 {
@@ -323,7 +324,7 @@ namespace Plugin.FirebasePushNotification
 
                 }
             }
-            else if ($"{priority}".ToLower() == "default" || $"{priority}".ToLower() == "low" || $"{priority}".ToLower() == "min")
+            else if ($"{priority}".Equals("default", StringComparison.CurrentCultureIgnoreCase) || $"{priority}".Equals("low", StringComparison.CurrentCultureIgnoreCase) || $"{priority}".Equals("min", StringComparison.CurrentCultureIgnoreCase))
             {
                 if (CurrentNotificationPresentationOption.HasFlag(UNNotificationPresentationOptions.Alert))
                 {
@@ -361,14 +362,15 @@ namespace Plugin.FirebasePushNotification
             _onNotificationError?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationErrorEventArgs(FirebasePushNotificationErrorType.RegistrationFailed, error.Description));
         }
 
-        public void ApplicationReceivedRemoteMessage(RemoteMessage remoteMessage)
-        {
-            System.Console.WriteLine(remoteMessage.AppData);
-            System.Diagnostics.Debug.WriteLine("ApplicationReceivedRemoteMessage");
-            var parameters = GetParameters(remoteMessage.AppData);
-            _onNotificationReceived?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationDataEventArgs(parameters));
-            CrossFirebasePushNotification.Current.NotificationHandler?.OnReceived(parameters);
-        }
+        //public void ApplicationReceivedRemoteMessage(RemoteMessage remoteMessage)
+        //{
+        //    Firebase.CloudMessaging.MessageStatus.
+        //    System.Console.WriteLine(remoteMessage.AppData);
+        //    System.Diagnostics.Debug.WriteLine("ApplicationReceivedRemoteMessage");
+        //    var parameters = GetParameters(remoteMessage.AppData);
+        //    _onNotificationReceived?.Invoke(CrossFirebasePushNotification.Current, new FirebasePushNotificationDataEventArgs(parameters));
+        //    CrossFirebasePushNotification.Current.NotificationHandler?.OnReceived(parameters);
+        //}
 
         private static IDictionary<string, object> GetParameters(NSDictionary data)
         {
@@ -480,6 +482,7 @@ namespace Plugin.FirebasePushNotification
 
         }
 
+        [Obsolete("Upstream messaging through direct channel is deprecated. Not working anymore.", true)]
         public void SendDeviceGroupMessage(IDictionary<string, string> parameters, string groupKey, string messageId, int timeOfLive)
         {
             if (hasToken)
@@ -491,9 +494,9 @@ namespace Plugin.FirebasePushNotification
                         message.Add(new NSString(p.Key), new NSString(p.Value));
                     }
 
-                    Messaging.SharedInstance.SendMessage(message, groupKey, messageId, timeOfLive);
+                    // Messaging.SharedInstance.SendMessage(message, groupKey, messageId, timeOfLive); //Old
                 }
-                  
+
             }
         }
 
@@ -609,8 +612,8 @@ namespace Plugin.FirebasePushNotification
 
         public async Task<string> GetTokenAsync()
         {
-            var result = await InstanceId.SharedInstance.GetInstanceIdAsync();
-            return result?.Token;
+            var result = await Messaging.SharedInstance.FetchTokenAsync();//InstanceId.SharedInstance.GetInstanceIdAsync(); Old
+            return result;
         }
     }
 

--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
@@ -446,10 +446,7 @@ namespace Plugin.FirebasePushNotification
 
         public void UnsubscribeAll()
         {
-            for (nuint i = 0; i < currentTopics.Count; i++)
-            {
-                Unsubscribe(currentTopics.GetItem<NSString>(i));
-            }
+            Unsubscribe(SubscribedTopics);
         }
 
         public void Unsubscribe(string[] topics)

--- a/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
+++ b/Plugin.FirebasePushNotification/FirebasePushNotificationManager.ios.cs
@@ -24,7 +24,7 @@ namespace Plugin.FirebasePushNotification
         private static NSString FirebaseTopicsKey = new NSString("FirebaseTopics");
         private const string FirebaseTokenKey = "FirebaseToken";
         private static NSMutableArray currentTopics = (NSUserDefaults.StandardUserDefaults.ValueForKey(FirebaseTopicsKey) as NSArray ?? new NSArray()).MutableCopy() as NSMutableArray;
-        public string Token { get { return string.IsNullOrEmpty(Messaging.SharedInstance.FcmToken) ? (NSUserDefaults.StandardUserDefaults.StringForKey(FirebaseTokenKey) ?? string.Empty) : Messaging.SharedInstance.FcmToken; } }
+        public string Token { get { return string.IsNullOrEmpty(Messaging.SharedInstance?.FcmToken) ? (NSUserDefaults.StandardUserDefaults.StringForKey(FirebaseTokenKey) ?? string.Empty) : Messaging.SharedInstance?.FcmToken; } }
 
         private static IList<NotificationUserCategory> usernNotificationCategories = new List<NotificationUserCategory>();
         private static FirebasePushNotificationTokenEventHandler _onTokenRefresh;

--- a/Plugin.FirebasePushNotification/Plugin.FirebasePushNotification.csproj
+++ b/Plugin.FirebasePushNotification/Plugin.FirebasePushNotification.csproj
@@ -66,8 +66,9 @@
     <Compile Include="Platforms\Ios\**\*.cs" />
     <Compile Include="Platforms\Xamarin\**\*.cs" />
     <Compile Include="**\*.ios.cs" />
-    <Compile Include="**\*.ios.*.cs" />
-    <PackageReference Include="Xamarin.Firebase.iOS.CloudMessaging" Version="4.3.0" />
+    <Compile Include="**\*.ios.*.cs" />   
+    <!--<PackageReference Include="Xamarin.Firebase.iOS.CloudMessaging" Version="4.3.0" />-->
+    <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="10.16.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.mac')) ">

--- a/Plugin.FirebasePushNotification/Plugin.FirebasePushNotification.csproj
+++ b/Plugin.FirebasePushNotification/Plugin.FirebasePushNotification.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;monoandroid12.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;monoandroid13.0</TargetFrameworks>
     <!--<TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.17763;$(TargetFrameworks)</TargetFrameworks>-->
 

--- a/Plugin.FirebasePushNotification/Plugin.FirebasePushNotification.csproj
+++ b/Plugin.FirebasePushNotification/Plugin.FirebasePushNotification.csproj
@@ -106,9 +106,8 @@
     <AndroidResource Include="Resources\**\*.json" Generator="MSBuild:UpdateAndroidResources" />
     <Compile Include="**\*.android.cs" />
     <Compile Include="**\*.android.*.cs" />
-    <PackageReference Include="Xamarin.Firebase.Common" Version="120.0.0.5" />
-    <PackageReference Include="Xamarin.Firebase.Messaging" Version="122.0.0.5" />
-    <PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.0.1" />
+    <PackageReference Include="Xamarin.Firebase.Common" Version="120.4.2.2" />
+    <PackageReference Include="Xamarin.Firebase.Messaging" Version="123.3.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">

--- a/Plugin.FirebasePushNotification/PushNotificationActionReceiver.android.cs
+++ b/Plugin.FirebasePushNotification/PushNotificationActionReceiver.android.cs
@@ -17,8 +17,8 @@ namespace Plugin.FirebasePushNotification
             {
                 foreach (var key in extras.KeySet())
                 {
-                    parameters.Add(key, $"{extras.Get(key)}");
-                    System.Diagnostics.Debug.WriteLine(key, $"{extras.Get(key)}");
+                    parameters.Add(key, extras.GetString(key));
+                    System.Diagnostics.Debug.WriteLine(key, extras.GetString(key));
                 }
             }
             FirebasePushNotificationManager.RegisterAction(parameters);

--- a/Plugin.FirebasePushNotification/PushNotificationDeletedReceiver.android.cs
+++ b/Plugin.FirebasePushNotification/PushNotificationDeletedReceiver.android.cs
@@ -15,8 +15,8 @@ namespace Plugin.FirebasePushNotification
             {
                 foreach (var key in extras.KeySet())
                 {
-                    parameters.Add(key, $"{extras.Get(key)}");
-                    System.Diagnostics.Debug.WriteLine(key, $"{extras.Get(key)}");
+                    parameters.Add(key, extras.GetString(key));
+                    System.Diagnostics.Debug.WriteLine(key, extras.GetString(key));
                 }
             }
 

--- a/samples/FirebasePushSample.Android/FirebasePushSample.Android.csproj
+++ b/samples/FirebasePushSample.Android/FirebasePushSample.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
     <JavaMaximumHeapSize />

--- a/samples/FirebasePushSample/FirebasePushSample.csproj
+++ b/samples/FirebasePushSample/FirebasePushSample.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="10.16.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.2" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
   </ItemGroup>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature
### :arrow_heading_down: What is the current behavior?
The condition to skip displaying a notification with android is confusing/complicated: https://github.com/CrossGeeks/FirebasePushNotificationPlugin/blob/d86266a9f45687b418f5f1e69c348681d1ff6e27/Plugin.FirebasePushNotification/DefaultPushNotificationHandler.android.cs#L151
More infos: https://github.com/CrossGeeks/FirebasePushNotificationPlugin/issues/434
### :new: What is the new behavior (if this is a feature change)?
With this change it is possible to implement a custom condition or simple skip the condition (return false). Just override the virtual method.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
